### PR TITLE
added buyerId and serviceStatus to userServices hook dependencies

### DIFF
--- a/src/hooks/useServices.ts
+++ b/src/hooks/useServices.ts
@@ -84,7 +84,7 @@ const useServices = (
       }
     };
     fetchData();
-  }, [numberPerPage, offset, searchQuery]);
+  }, [numberPerPage, offset, searchQuery, buyerId, serviceStatus]);
 
   const loadMore = () => {
     numberPerPage ? setOffset(offset + numberPerPage) : '';


### PR DESCRIPTION
The useServices hook was not refreshing the services list in case the userId changed from undefined to a defined value. Similarly, if the serviceStatus passed to the hook changed from undefined to a defined value, this would not trigger a refreshed list.

The reason is that the hook is using a `useEffect` to all a function called `getServices` . However, the dependency array was missing `buyerId` and `serviceStatus` as dependencies