### PR TITLE
fixed query parameter

### DIFF
--- a/src/components/Form/ProposalForm.tsx
+++ b/src/components/Form/ProposalForm.tsx
@@ -188,7 +188,7 @@ function ProposalForm({
           },
           publicClient,
           tx,
-          'proposalRequest',
+          'proposal',
           cid,
         );
         setSubmitting(false);


### PR DESCRIPTION
It seems like there is no such thing as "proposalRequest" - it is supposed to be "proposal"

This causes an error when syncing on-chain data after creating/editing a proposal.
