### PR TITLE
Make Errors great again!!!!

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "starterkit",
       "version": "0.1.0",
       "dependencies": {
-        "@enzoferey/ethers-error-parser": "^0.2.2",
         "@headlessui/react": "^1.7.3",
         "@heroicons/react": "^2.0.12",
         "@iexec/dataprotector": "0.1.2",
@@ -2255,14 +2254,6 @@
       "peerDependencies": {
         "@envelop/core": "^3.0.6",
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@enzoferey/ethers-error-parser": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@enzoferey/ethers-error-parser/-/ethers-error-parser-0.2.2.tgz",
-      "integrity": "sha512-OZuPvUEIWwUFhR1vWOAMA6lTKCxGLTPxH2nEbg7V5uO1jvuKzQdHdvzmrT8ljHb0JAIN+oHDr3ArsciVxSIXIg==",
-      "peerDependencies": {
-        "ethers": "^5.7.0"
       }
     },
     "node_modules/@esbuild/android-arm": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@enzoferey/ethers-error-parser": "^0.2.2",
     "@headlessui/react": "^1.7.3",
     "@heroicons/react": "^2.0.12",
     "@iexec/dataprotector": "0.1.2",

--- a/src/utils/toast.tsx
+++ b/src/utils/toast.tsx
@@ -1,9 +1,7 @@
-import { getParsedEthersError, RETURN_VALUE_ERROR_CODES } from '@enzoferey/ethers-error-parser';
-import { EthersError } from '@enzoferey/ethers-error-parser/dist/types';
 import { toast } from 'react-toastify';
 import MultiStepsTransactionToast from '../components/MultiStepsTransactionToast';
 import { graphIsSynced, graphUserIsSynced } from '../queries/global';
-import { Client, Hash, Transaction, WalletClient } from 'viem';
+import { BaseError, Hash } from 'viem';
 import { PublicClient } from 'wagmi';
 
 interface IMessages {
@@ -143,10 +141,11 @@ export const createTalentLayerIdTransactionToast = async (
 };
 
 function getParsedErrorMessage(error: any) {
-  const parsedEthersError = getParsedEthersError(error as EthersError);
-  if (parsedEthersError.errorCode === RETURN_VALUE_ERROR_CODES.REJECTED_TRANSACTION) {
-    return `${parsedEthersError.errorCode} - user rejected transaction`;
-  } else {
-    return `${parsedEthersError.errorCode} - ${parsedEthersError.context}`;
+  const parsedViemError  = error as BaseError;
+
+  if (parsedViemError && parsedViemError?.name && parsedViemError?.shortMessage) {
+    return `${parsedViemError.name} - ${parsedViemError.shortMessage}`
   }
+
+  return "Unknown error occurred";
 }


### PR DESCRIPTION
During the viem and sdk migrations of the starter kit, errors were ignored 😢

In this PR, they are given their due time and resurfaced back in the error toasts



---
Now the toast will show an error that looks something like this:

<img width="1003" alt="Screenshot 2023-11-08 at 6 50 32 PM" src="https://github.com/TalentLayer-Labs/starter-kit/assets/29460541/8b0f4de4-9c21-4970-81fa-5fb5fbd18a3c">